### PR TITLE
Update aws_c_cal_jll to version 0.9.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsCal"
 uuid = "ef519ef6-af43-41a0-8ac4-eb81328190af"
-version = "1.1.7"
+version = "1.1.8"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,7 +11,7 @@ aws_c_cal_jll = "70f11efc-bab2-57f1-b0f3-22aad4e67c4b"
 Aqua = "0.7,0.8"
 CEnum = "0.5"
 LibAwsCommon = "1.2"
-aws_c_cal_jll = "=0.9.5"
+aws_c_cal_jll = "=0.9.6"
 julia = "1.6"
 Test = "1.11"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -8,4 +8,4 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_cal_jll = "=0.9.5"
+aws_c_cal_jll = "=0.9.6"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_19
+    __JL_Ctag_21
 
 Documentation not found.
 """
-@cenum __JL_Ctag_19::UInt32 begin
+@cenum __JL_Ctag_21::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -960,16 +1002,6 @@ Documentation not found.
     AWS_CAL_RSA_SIGNATURE_PKCS1_5_SHA256 = 0
     AWS_CAL_RSA_SIGNATURE_PKCS1_5_SHA1 = 1
     AWS_CAL_RSA_SIGNATURE_PSS_SHA256 = 2
-end
-
-"""
-    __JL_Ctag_85
-
-Documentation not found.
-"""
-@cenum __JL_Ctag_85::UInt32 begin
-    AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
-    AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end
 
 """

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_16
+    __JL_Ctag_18
 
 Documentation not found.
 """
-@cenum __JL_Ctag_16::UInt32 begin
+@cenum __JL_Ctag_18::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -960,16 +1002,6 @@ Documentation not found.
     AWS_CAL_RSA_SIGNATURE_PKCS1_5_SHA256 = 0
     AWS_CAL_RSA_SIGNATURE_PKCS1_5_SHA1 = 1
     AWS_CAL_RSA_SIGNATURE_PSS_SHA256 = 2
-end
-
-"""
-    __JL_Ctag_85
-
-Documentation not found.
-"""
-@cenum __JL_Ctag_85::UInt32 begin
-    AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
-    AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end
 
 """

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_16
+    __JL_Ctag_18
 
 Documentation not found.
 """
-@cenum __JL_Ctag_16::UInt32 begin
+@cenum __JL_Ctag_18::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_79
+    __JL_Ctag_86
 
 Documentation not found.
 """
-@cenum __JL_Ctag_79::UInt32 begin
+@cenum __JL_Ctag_86::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_16
+    __JL_Ctag_18
 
 Documentation not found.
 """
-@cenum __JL_Ctag_16::UInt32 begin
+@cenum __JL_Ctag_18::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_79
+    __JL_Ctag_86
 
 Documentation not found.
 """
-@cenum __JL_Ctag_79::UInt32 begin
+@cenum __JL_Ctag_86::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_19
+    __JL_Ctag_21
 
 Documentation not found.
 """
-@cenum __JL_Ctag_19::UInt32 begin
+@cenum __JL_Ctag_21::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_76
+    __JL_Ctag_83
 
 Documentation not found.
 """
-@cenum __JL_Ctag_76::UInt32 begin
+@cenum __JL_Ctag_83::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_16
+    __JL_Ctag_18
 
 Documentation not found.
 """
-@cenum __JL_Ctag_16::UInt32 begin
+@cenum __JL_Ctag_18::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_16
+    __JL_Ctag_18
 
 Documentation not found.
 """
-@cenum __JL_Ctag_16::UInt32 begin
+@cenum __JL_Ctag_18::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -778,6 +778,48 @@ function aws_set_sha1_new_fn(fn)
 end
 
 """
+    aws_hkdf_hmac_type
+
+Only supports SHA512 hmac for now. No reason other than thats the only one we need for now.
+"""
+@cenum aws_hkdf_hmac_type::UInt32 begin
+    HKDF_HMAC_SHA512 = 0
+end
+
+"""
+    aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+
+Derive hkdf. hmac\\_type - type of hmac to use ikm - input keying material salt - salt (optional) all zeroes if not provided. info - extra info (optional). out\\_buf - must have enough capacity to fit result (i.e. have at least length left) length - length of generated key
+
+### Prototype
+```c
+int aws_hkdf_derive( struct aws_allocator *allocator, enum aws_hkdf_hmac_type hmac_type, struct aws_byte_cursor ikm, struct aws_byte_cursor salt, struct aws_byte_cursor info, struct aws_byte_buf *out_buf, size_t length);
+```
+"""
+function aws_hkdf_derive(allocator, hmac_type, ikm, salt, info, out_buf, length)
+    ccall((:aws_hkdf_derive, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_hkdf_hmac_type, aws_byte_cursor, aws_byte_cursor, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, hmac_type, ikm, salt, info, out_buf, length)
+end
+
+# typedef int ( aws_hkdf_fn ) ( struct aws_allocator * allocator , enum aws_hkdf_hmac_type hmac_type , struct aws_byte_cursor ikm , struct aws_byte_cursor salt , struct aws_byte_cursor info , struct aws_byte_buf * out_buf , size_t length )
+"""
+Documentation not found.
+"""
+const aws_hkdf_fn = Cvoid
+
+"""
+    aws_set_hkdf_fn(fn)
+
+Documentation not found.
+### Prototype
+```c
+void aws_set_hkdf_fn(aws_hkdf_fn *fn);
+```
+"""
+function aws_set_hkdf_fn(fn)
+    ccall((:aws_set_hkdf_fn, libaws_c_cal), Cvoid, (Ptr{aws_hkdf_fn},), fn)
+end
+
+"""
     aws_hmac_vtable
 
 Documentation not found.
@@ -963,11 +1005,11 @@ Documentation not found.
 end
 
 """
-    __JL_Ctag_16
+    __JL_Ctag_18
 
 Documentation not found.
 """
-@cenum __JL_Ctag_16::UInt32 begin
+@cenum __JL_Ctag_18::UInt32 begin
     AWS_CAL_RSA_MIN_SUPPORTED_KEY_SIZE_IN_BITS = 1024
     AWS_CAL_RSA_MAX_SUPPORTED_KEY_SIZE_IN_BITS = 4096
 end


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_cal_jll** to version **0.9.6**
- Updated **JuliaServices/LibAwsCal.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings