### PR TITLE
Update aws_c_cal_jll to version 0.9.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsCal"
 uuid = "ef519ef6-af43-41a0-8ac4-eb81328190af"
-version = "1.1.11"
+version = "1.1.12"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,7 +11,7 @@ aws_c_cal_jll = "70f11efc-bab2-57f1-b0f3-22aad4e67c4b"
 Aqua = "0.7,0.8"
 CEnum = "0.5"
 LibAwsCommon = "1.2"
-aws_c_cal_jll = "=0.9.11"
+aws_c_cal_jll = "=0.9.12"
 julia = "1.6"
 Test = "1.11"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -8,4 +8,4 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_cal_jll = "=0.9.11"
+aws_c_cal_jll = "=0.9.12"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -412,6 +412,19 @@ function aws_ecc_decode_signature_der_to_raw(allocator, signature, out_r, out_s)
 end
 
 """
+    aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+
+Documentation not found.
+### Prototype
+```c
+int aws_ecc_decode_signature_der_to_raw_padded( struct aws_allocator *allocator, struct aws_byte_cursor signature, struct aws_byte_buf *out, size_t pad_to);
+```
+"""
+function aws_ecc_decode_signature_der_to_raw_padded(allocator, signature, out, pad_to)
+    ccall((:aws_ecc_decode_signature_der_to_raw_padded, libaws_c_cal), Cint, (Ptr{aws_allocator}, aws_byte_cursor, Ptr{aws_byte_buf}, Csize_t), allocator, signature, out, pad_to)
+end
+
+"""
     aws_ecc_encode_signature_raw_to_der(allocator, r, s, out_signature)
 
 Documentation not found.


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_cal_jll** to version **0.9.12**
- Updated **JuliaServices/LibAwsCal.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings